### PR TITLE
Add AppArmor profile and run container as non-root user

### DIFF
--- a/002-middlewares.yaml
+++ b/002-middlewares.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   forwardAuth:
     address: http://traefik-forward-auth
-    trustForwardHeader: 'true'
+    trustForwardHeader: true
     authResponseHeaders:
       - X-Forwarded-User

--- a/004-deployment.yaml
+++ b/004-deployment.yaml
@@ -16,10 +16,21 @@ spec:
     metadata:
       labels:
         app: traefik-forward-auth
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/traefik-forward-auth: runtime/default
     spec:
       containers:
         - name: traefik-forward-auth
           image: thomseddon/traefik-forward-auth
+          imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: http
               containerPort: 4181
@@ -69,4 +80,3 @@ spec:
                 configMapKeyRef:
                   name: traefik-forward-auth
                   key: AUTH_HOST
-            


### PR DESCRIPTION
The traefik-forward-auth container is run as a non-root user, using nobody:nogroup in this deployment.

An AppArmor profile has been added to the deployment, all capabilities dropped, and the root filesystem is not writable.