### PR TITLE
Remove middleware from ingressroute

### DIFF
--- a/001-config.yaml
+++ b/001-config.yaml
@@ -11,5 +11,5 @@ data:
   AUTH_HOST: auth.mydomain.io
   URL_PATH: /_oauth
   DEFAULT_PROVIDER: oidc
-  PROVIDERS_OIDC_ISSUER_URL: https://keycloak.mydomain.io/auth/realms/master
+  PROVIDERS_OIDC_ISSUER_URL: https://keycloak.mydomain.io/auth/realms/homelab
   PROVIDERS_OIDC_CLIENT_ID: traefik-forward-auth

--- a/005-ingressroute.yaml
+++ b/005-ingressroute.yaml
@@ -11,9 +11,6 @@ spec:
   routes:
     - kind: Rule
       match: Host(`auth.mydomain.io`)
-      middlewares:
-        - name: traefik-forward-auth
-          namespace: kube-system
       services:
         - name: traefik-forward-auth
           port: 80

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ Refer to the documentation on
 and their values based on the configuration in the [001-config.yaml] file in
 this repository.
 
+### Middlewares
+
+The forward authentication middleware can be configured at a "global" level,
+for example within the same namespace as the Traefik deployment. This can then
+be referenced by ingress/ingressroutes in other namespaces.
+
+In Traefik v2.3 a change was made so that by default it was not possible to
+reference resources in other namespaces. To enable this the Traefik
+`providers.kubernetescrd.allowCrossNamespace` configuration property needs to
+be set to a value of `true`. If this is not set to `true` then ingresses in
+other namespaces will not be able to reference this "global" middleware.
+
 ### Deployment
 
 Apply the manifests in order (prefixed by number) to install the secrets,

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ OWUwNTBmZTM5ODQwNjE1NzJmZGE1ZjQ2NGE4YjVkOTgK
 ### Configuration
 
 The [001-config.yaml] file needs to be updated with the configuration for your
-OIDC provider and other information.
+OIDC provider and other information. In the example configuration a Keycloak
+realm named `homelab` is used.
 
 Refer to the documentation on
 <https://github.com/thomseddon/traefik-forward-auth> as to what the items are
@@ -120,6 +121,11 @@ this repository.
 Apply the manifests in order (prefixed by number) to install the secrets,
 config, deployment and ingress route for the [`traefik-forward-auth`] delegated
 authentication service.
+
+The example configuration is using the original `thomseddon/traefik-forward-auth`
+Docker image. I have provided the [`sleighzy/traefik-forward-auth`] image within
+Docker Hub which offers arm64 support for systems such as Raspberry Pi and the
+macOS M1 Apple Silicon chip that can be used instead.
 
 ## Ingress vs IngresssRoute
 
@@ -214,5 +220,7 @@ Credits to the following for getting this going:
   https://docs.traefik.io/routing/providers/kubernetes-crd/
 [mit license]: https://img.shields.io/badge/License-MIT-blue.svg
 [openid connect]: https://openid.net/connect/
+[`sleighzy/traefik-forward-auth`]:
+  https://hub.docker.com/r/sleighzy/traefik-forward-auth
 [traefik]: https://containo.us/traefik/
 [`traefik-forward-auth`]: https://github.com/thomseddon/traefik-forward-auth


### PR DESCRIPTION
* The forward authentication middleware does not need to be applied to the actual ingressroute that is used for routing traffic to the forward auth service.

* Add note about needing to enable allowCrossNamespace setting in Traefik to use middleware from other namespaces.

* Add note that the https://hub.docker.com/r/sleighzy/traefik-forward-auth Docker image can be used for arm64 support.